### PR TITLE
Add meta/main.yml file, so ansible-galaxy install works

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,22 @@
+galaxy_info:
+  role_name: wireguard-private-networking
+  author: mawalu
+  description: Build your own multi server private network using wireguard and ansible
+  issue_tracker_url: https://github.com/mawalu/wireguard-private-networking/issues
+  license: MIT
+  min_ansible_version: 2.7
+  platforms:
+  - name: Ubuntu
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+
+  galaxy_tags:
+  - wireguard
+  - vpn
+  - networking
+
+dependencies: []
+


### PR DESCRIPTION
In order to install this role with ansible-galaxy, meta/main.yml is needed. This pull request adds meta/main.yaml to accomplish this. I filled the file based on the data in the git repo.

By the way. This role is very helpful.
