### PR TITLE
Fix bug in interface template

### DIFF
--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -31,10 +31,10 @@ AllowedIPs = {{ client_vpn_ip }}
 [Peer]
 PublicKey = {{ node.key }}
 AllowedIPs = {{ node.ip }}
-{% if node.endpoint %}
+{% if node.endpoint is defined %}
 Endpoint = {{ node.endpoint }}
 {% endif %}
-{% if node.endpoint %}
+{% if node.keepalive is defined %}
 PersistentKeepalive = {{ node.keepalive }}
 {% endif %}
 


### PR DESCRIPTION
You need to use `is defined` to properly check if an attribute of a dict exists. The current check always passes even if `endpoint` is not defined.