### PR TITLE
Added support for CentOS 7-8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,55 @@
   when:
     - ansible_distribution == "Archlinux"
 
+- name: Install wireguard (CentOS 8)
+  block:
+    - name: Install wireguard (CentOS 8)
+      dnf:
+        name:
+          - elrepo-release
+          - epel-release
+        state: present
+
+    - dnf:
+        name:
+          - kmod-wireguard
+          - wireguard-tools
+        state: present
+
+    - file:
+        path: /etc/wireguard
+        state: directory
+        mode: u=rwx,g=rx,o=rx
+
+  when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "8"
+
+- name: Install wireguard (CentOS 7)
+  block:
+    - name: Install wireguard (CentOS 7)
+      yum:
+        name:
+          - epel-release
+          - https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
+        state: present
+
+    - yum:
+        name:
+          - yum-plugin-elrepo
+        state: present
+
+    - yum:
+        name:
+          - kmod-wireguard
+          - wireguard-tools
+        state: present
+
+    - file:
+        path: /etc/wireguard
+        state: directory
+        mode: u=rwx,g=rx,o=rx
+
+  when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "7"
+
 - name: Read private key
   stat:
     path: "{{ wireguard_path }}/privatekey"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,9 +76,10 @@
         state: present
 
     - file:
-        path: /etc/wireguard
+        path: "{{ wireguard_path }}"
         state: directory
-        mode: u=rwx,g=rx,o=rx
+        mode: u=rwx,g=,o=
+        group: root
 
   when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "8"
 
@@ -103,9 +104,10 @@
         state: present
 
     - file:
-        path: /etc/wireguard
+        path: "{{ wireguard_path }}"
         state: directory
-        mode: u=rwx,g=rx,o=rx
+        mode: u=rwx,g=,o=
+        group: root
 
   when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "7"
 


### PR DESCRIPTION
I have added support for CentOS 7-8. My testing confirms that the changes work as expected. 

There is one issue: The WireGuard service fails to start as a reboot is required to load the Linux Kernel module. I believe this would also be an issue with the role as it currently exists? I presume rebooting the machine is beyond the scope of the role?