### PR TITLE
Add support for Opensuse Leap 15.1 and 15.2

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,10 @@ galaxy_info:
     versions:
     - 7
     - 8
+  - name: OpenSuse
+    versions:
+    - 15.1
+    - 15.2
   galaxy_tags:
   - wireguard
   - vpn

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,6 +95,15 @@
 
   when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "7"
 
+- name: Install wireguard and tools (zypper)
+  zypper:
+    name:
+      - iptables
+      - wireguard-tools
+    state: present
+  when:
+    - ansible_distribution == "openSUSE Leap"
+
 - name: Read private key
   stat:
     path: "{{ wireguard_path }}/privatekey"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,6 @@
 - name: Install wireguard and tools (zypper)
   zypper:
     name:
-      - iptables
       - wireguard-tools
     state: present
   when:


### PR DESCRIPTION
As title says, the PR adds support for:

- OpenSuse Leap 15.1
- OpenSuse Leap 15.2

I've tested the role on both and it runs fine. The molecule tests pass as well. It should probably work on the latest SLES as well, but I cannot test that. 