### PR TITLE
add notifier for server config generation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -157,6 +157,9 @@
     group: root
     mode: "u=rw,g=r,o="
   register: config
+  notify:
+    - Enable wg-quick service
+    - Restart wg-quick service
 
 - name: Generate client's config
   template:


### PR DESCRIPTION
In our case we are configuring server mesh only (for now). It make sense to add notifiers for server config also, because in any case it will run once.