### PR TITLE
start container with systemd as PID1

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+warn_list:
+  - git-latest

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -4,7 +4,19 @@ jobs:
   molecule:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
         with:
-          path: "${{ github.repository }}"
-      - uses: mawalu/molecule-action@master
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint
+  ansible-lint .
 platforms:
   - name: instance
     image: geerlingguy/docker-ubuntu2004-ansible:latest

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,12 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: docker.io/pycontribs/debian:latest
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - /lib/modules:/lib/modules
+    command: /lib/systemd/systemd
     pre_build_image: true
+    privileged: true
 provisioner:
   name: ansible

--- a/molecule/default/testvars.yml
+++ b/molecule/default/testvars.yml
@@ -16,12 +16,12 @@ client_wireguard_path: "~/wg.conf" # path on localhost to write client config, i
 wireguard_additional_peers:
   - comment: martin
     ip: 10.2.3.4
-    key: your_wireguard_public_key
+    key: e+2fJq6/XmsxezxzNdXau9NMxevNRNLKbGW3nBq0exM=
   - comment: other_network
     ip: 10.32.0.0/16
-    key: their_wireguard_public_key
+    key: e+2fJq6/XmsxezxzNdXau9NMxevNRNLKbGW3nBq0exM=
     keepalive: 20
-    endpoint: some.endpoint:2230
+    endpoint: example.com:2230
 
-wireguard_post_up: "iptables ..." # PostUp hook command
-wireguard_post_down: "iptables"   # PostDown hook command
+wireguard_post_up: "echo iptables" # PostUp hook command
+wireguard_post_down: "echo iptables"   # PostDown hook command

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.docker
+  - name: community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
       copy:
         src: templates/backports.list
         dest: /etc/apt/sources.list.d/backport.list
+        mode: 0644
 
     - name: Add backports repository key (Debian)
       apt_key:
@@ -208,6 +209,7 @@
   file:
     path: "{{ wireguard_path }}"
     state: directory
+    mode: 0755
 
 - name: Read private key
   stat:


### PR DESCRIPTION
The molecule testing failed, because the container used did not support systemd nor the command systemctl. In order to enable system services in a container, it must be started with systemd as PID1. Jeff Geerling already prepared a lot of docker containers exactly for that use case. I changed the used pycontrib container to the debian10 container from Jeff Geerling.

Unfortunately, the build is still failing during the step 'Restart wg-quick service' with the error 'Service is in unkown state'. This is due to a known bug in Ansible (see https://github.com/ansible/ansible/issues/71528). It should be fixed with the next Ansible 2.10.4 and 2.9.16 release (https://github.com/ansible/ansible/issues/71528#issuecomment-729778048).

My proposition is, to let the PR open, until the update of Ansible has been released. I will then check again if the build succeeds and only then to merge the PR.