### PR TITLE
Support for separate public address added

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ debian_enable_backports: true # if the debian backports repos should be added on
 client_vpn_ip: "" # if set an additional wireguard config file will be generated at the specified path on localhost
 client_wireguard_path: "~/wg.conf" # path on localhost to write client config, if client_vpn_ip is set 
 
+public_addr: "" # if set, this address will be used to connect to the wireguard peer instead of the address in the inventory. Useful if you are configuring over a different network than wireguard is using.
+
 # a list of additional peers that will be added to each server
 wireguard_additional_peers:
   - comment: martin

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ $ ansible-galaxy install mawalu.wireguard_private_networking
 
 Install this role, assign a `vpn_ip` variable to every host that should be part of the network and run the role. Plese make sure to allow the VPN port (default is 5888) in your firewall. Here is a small example configuration:
 
+Optionally, you can set a `public_addr` on each host. This address will be used to connect to the wireguard peer instead of the address in the inventory. Useful if you are configuring over a different network than wireguard is using. e.g. ansible connects over a LAN to your peer.
+
 ```yaml
 # inventory host file
 
@@ -27,7 +29,7 @@ wireguard:
   hosts:
     1.1.1.1:
       vpn_ip: 10.1.0.1/32
-      public_addr: "example.com" # optional: if set, this address will be used to connect to the wireguard peer instead of the address in the inventory. Useful if you are configuring over a different network than wireguard is using.
+      public_addr: "example.com" # optional
     2.2.2.2:
       vpn_ip: 10.1.0.2/32
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ wireguard:
   hosts:
     1.1.1.1:
       vpn_ip: 10.1.0.1/32
+      public_addr: "example.com" # optional: if set, this address will be used to connect to the wireguard peer instead of the address in the inventory. Useful if you are configuring over a different network than wireguard is using.
     2.2.2.2:
       vpn_ip: 10.1.0.2/32
 
@@ -70,8 +71,6 @@ debian_enable_backports: true # if the debian backports repos should be added on
 
 client_vpn_ip: "" # if set an additional wireguard config file will be generated at the specified path on localhost
 client_wireguard_path: "~/wg.conf" # path on localhost to write client config, if client_vpn_ip is set 
-
-public_addr: "" # if set, this address will be used to connect to the wireguard peer instead of the address in the inventory. Useful if you are configuring over a different network than wireguard is using.
 
 # a list of additional peers that will be added to each server
 wireguard_additional_peers:

--- a/templates/client.conf.j2
+++ b/templates/client.conf.j2
@@ -6,7 +6,7 @@ PrivateKey = {{ client_privatekey.content | b64decode | trim }}
 [Peer]
 PublicKey = {{ hostvars[node].public.content | b64decode | trim }}
 AllowedIPs = {{ hostvars[node].vpn_ip }}
-Endpoint = {{ hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
+Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host']) | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
 PersistentKeepalive = 25
 
 {% endfor %}

--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -17,7 +17,7 @@ MTU = {{ wireguard_mtu }}
 [Peer]
 PublicKey = {{ hostvars[node].public.content | b64decode | trim }}
 AllowedIPs = {{ hostvars[node].vpn_ip }}
-Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname'])) }}:{{ wireguard_port }}
+Endpoint = {{ hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
 
 {% endif %}
 {% endfor %}

--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -17,7 +17,7 @@ MTU = {{ wireguard_mtu }}
 [Peer]
 PublicKey = {{ hostvars[node].public.content | b64decode | trim }}
 AllowedIPs = {{ hostvars[node].vpn_ip }}
-Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname'])) }}:{{ wireguard_port }}
+Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host']) | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
 
 {% endif %}
 {% endfor %}

--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -17,7 +17,7 @@ MTU = {{ wireguard_mtu }}
 [Peer]
 PublicKey = {{ hostvars[node].public.content | b64decode | trim }}
 AllowedIPs = {{ hostvars[node].vpn_ip }}
-Endpoint = {{ hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
+Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname'])) }}:{{ wireguard_port }}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Added support for a separate public address that can be declared with a variable on each host.
That is necessary if the management with ansible is done over a dedicated management net and not over the same public net wireguard is using.

Edit: Sorry for the commit mess. I accidentally mixed it with my other PR und did a bad job cleaning it up.