### PR TITLE
Added support for the Raspberry Pi Zero W and possibly other armv61 based Rasperry Pis

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ wireguard_mtu: 1500 # Optionally a MTU to set in the wg-quick file. Not set by d
 
 debian_enable_backports: true # if the debian backports repos should be added on debian machines
 
+wireguard_sources_path: "/var/cache" # Location to clone the WireGuard sources if manual build is required
+
 client_vpn_ip: "" # if set an additional wireguard config file will be generated at the specified path on localhost
 client_wireguard_path: "~/wg.conf" # path on localhost to write client config, if client_vpn_ip is set 
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ wireguard_mtu: 1500 # Optionally a MTU to set in the wg-quick file. Not set by d
 
 debian_enable_backports: true # if the debian backports repos should be added on debian machines
 
+allow_build_from_source: true # Caution: Might trigger reboot. Flag whether the build from source is allowed. It might be possible to reboot the host.
+
 wireguard_sources_path: "/var/cache" # Location to clone the WireGuard sources if manual build is required
 
 client_vpn_ip: "" # if set an additional wireguard config file will be generated at the specified path on localhost
-client_wireguard_path: "~/wg.conf" # path on localhost to write client config, if client_vpn_ip is set 
+client_wireguard_path: "~/wg.conf" # path on localhost to write client config, if client_vpn_ip is set
 
 # a list of additional peers that will be added to each server
 wireguard_additional_peers:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ wireguard_mtu: 1500 # Optionally a MTU to set in the wg-quick file. Not set by d
 
 debian_enable_backports: true # if the debian backports repos should be added on debian machines
 
-allow_build_from_source: true # Caution: Might trigger reboot. Flag whether the build from source is allowed. It might be possible to reboot the host.
+# Raspberry Pi Zero support
+# Needs kernel headers and manual compilation of wireguard, opt in via flag, install `community.general` collection
+# Caution: Might trigger a reboot.
+allow_build_from_source: true
 
 wireguard_sources_path: "/var/cache" # Location to clone the WireGuard sources if manual build is required
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 wireguard_port: "5888"
 wireguard_path: "/etc/wireguard"
 
+wireguard_sources_path: "/var/cache"
+
 wireguard_network_name: "private"
 
 debian_enable_backports: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,18 +9,18 @@
     - ansible_distribution_major_version|int < 20
 
 - name: Add backports repository (Debian)
-  copy:
-    src: templates/backports.list
-    dest: /etc/apt/sources.list.d/backport.list
-  when:
-    - ansible_distribution == "Debian" and debian_enable_backports
+  block:
+    - name: Add backports repository list (Debian)
+      copy:
+        src: templates/backports.list
+        dest: /etc/apt/sources.list.d/backport.list
 
-- name: Add backports repository key (Debian)
-  apt_key:
-    url: https://ftp-master.debian.org/keys/archive-key-{{ ansible_lsb.release }}.asc
-    state: present
+    - name: Add backports repository key (Debian)
+      apt_key:
+        url: https://ftp-master.debian.org/keys/archive-key-{{ ansible_lsb.release }}.asc
+        state: present
   when:
-    - ansible_distribution == "Debian" and debian_enable_backports
+    - ansible_distribution == "Debian" and debian_enable_backports and ansible_architecture != "armv61"
 
 - name: Check that is proxmox
   stat:
@@ -42,13 +42,76 @@
     name: raspberrypi-kernel-headers
   when: ansible_distribution == "Debian" and ansible_lsb.id == "Raspbian"
 
+- name: Install WireGuard (Raspberry Pi 2, Raspberry Pi Zero W)
+  block:
+    - name: Install compile dependencies
+      apt:
+        update_cache: yes
+        state: present
+        name:
+          - bc
+          - bison
+          - checkinstall
+          - build-essential
+          - flex
+          - git
+          - libelf-dev
+          - libmnl-dev
+          - libncurses5-dev
+          - libssl-dev
+
+    - name: Download rpi-source
+      get_url:
+        url: 'https://raw.githubusercontent.com/RPi-Distro/rpi-source/master/rpi-source'
+        dest: '/usr/local/bin/rpi-source'
+        mode: u=rwx,g=rx,o=rx
+
+    - name: Run rpi-source
+      shell:
+        cmd: /usr/local/bin/rpi-source -q --tag-update
+
+    - name: Reboot Raspberry Pi and wait for it to come back up
+      reboot:
+
+    - name: Clone WireGuard source
+      git:
+        repo: 'https://git.zx2c4.com/wireguard-linux-compat/'
+        update: true
+        dest: /tmp/wireguard-linux-compat
+
+    - name: Build WireGuard
+      community.general.make:
+        chdir: /tmp/wireguard-linux-compat/src
+
+    - name: Install WireGuard
+      shell:
+        chdir: /tmp/wireguard-linux-compat/src
+        cmd: checkinstall -y --pkgname wireguard
+
+    - name: Clone WireGuard tools source
+      git:
+        repo: 'https://git.zx2c4.com/wireguard-tools'
+        update: true
+        dest: /tmp/wireguard-tools
+
+    - name: Build WireGuard tools
+      community.general.make:
+        chdir: /tmp/wireguard-tools/src
+
+    - name: Install WireGuard tools
+      shell:
+        chdir: /tmp/wireguard-tools/src
+        cmd: checkinstall -y --pkgname wireguard-tools
+
+  when: ansible_distribution == "Debian" and ansible_lsb.id == "Raspbian" and ansible_architecture == "armv6l"
+
 - name: Install wireguard (apt)
   apt:
     update_cache: yes
     state: present
     name: wireguard
   when:
-    - ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+    - ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" and ansible_architecture != "armv6l"
 
 - name: Install wireguard (pacman)
   pacman:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,48 +60,55 @@
           - libncurses5-dev
           - libssl-dev
 
-    - name: Download rpi-source
+    - name: Initial download of rpi-source
       get_url:
         url: 'https://raw.githubusercontent.com/RPi-Distro/rpi-source/master/rpi-source'
         dest: '/usr/local/bin/rpi-source'
         mode: u=rwx,g=rx,o=rx
 
     - name: Run rpi-source
-      shell:
-        cmd: /usr/local/bin/rpi-source -q --tag-update
+      command: /usr/local/bin/rpi-source
+      register: rpi_source_result
+      changed_when: "rpi_source_result.rc == 0"
+      failed_when: "'FAILED' in rpi_source_result.stderr"
 
     - name: Reboot Raspberry Pi and wait for it to come back up
       reboot:
+      when: rpi_source_result.changed
 
     - name: Clone WireGuard source
       git:
         repo: 'https://git.zx2c4.com/wireguard-linux-compat/'
         update: true
-        dest: {{ wireguard_sources_path }}/wireguard-linux-compat
+        dest: "{{ wireguard_sources_path }}/wireguard-linux-compat"
 
     - name: Build WireGuard
       community.general.make:
-        chdir: {{ wireguard_sources_path }}/wireguard-linux-compat/src
+        chdir: "{{ wireguard_sources_path }}/wireguard-linux-compat/src"
+      register: wireguard_build_result
 
     - name: Install WireGuard
-      shell:
-        chdir: {{ wireguard_sources_path }}/wireguard-linux-compat/src
+      command:
+        chdir: "{{ wireguard_sources_path }}/wireguard-linux-compat/src"
         cmd: checkinstall -y --pkgname wireguard
+      when: wireguard_build_result.changed
 
     - name: Clone WireGuard tools source
       git:
         repo: 'https://git.zx2c4.com/wireguard-tools'
         update: true
-        dest: {{ wireguard_sources_path }}/wireguard-tools
+        dest: "{{ wireguard_sources_path }}/wireguard-tools"
 
     - name: Build WireGuard tools
       community.general.make:
-        chdir: {{ wireguard_sources_path }}/wireguard-tools/src
+        chdir: "{{ wireguard_sources_path }}/wireguard-tools/src"
+      register: wireguard_tools_build_result
 
     - name: Install WireGuard tools
-      shell:
-        chdir: {{ wireguard_sources_path }}/wireguard-tools/src
+      command:
+        chdir: "{{ wireguard_sources_path }}/wireguard-tools/src"
         cmd: checkinstall -y --pkgname wireguard-tools
+      when: wireguard_tools_build_result.changed
 
   when: ansible_distribution == "Debian" and ansible_lsb.id == "Raspbian" and ansible_architecture == "armv6l"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,30 +77,30 @@
       git:
         repo: 'https://git.zx2c4.com/wireguard-linux-compat/'
         update: true
-        dest: /tmp/wireguard-linux-compat
+        dest: {{ wireguard_sources_path }}/wireguard-linux-compat
 
     - name: Build WireGuard
       community.general.make:
-        chdir: /tmp/wireguard-linux-compat/src
+        chdir: {{ wireguard_sources_path }}/wireguard-linux-compat/src
 
     - name: Install WireGuard
       shell:
-        chdir: /tmp/wireguard-linux-compat/src
+        chdir: {{ wireguard_sources_path }}/wireguard-linux-compat/src
         cmd: checkinstall -y --pkgname wireguard
 
     - name: Clone WireGuard tools source
       git:
         repo: 'https://git.zx2c4.com/wireguard-tools'
         update: true
-        dest: /tmp/wireguard-tools
+        dest: {{ wireguard_sources_path }}/wireguard-tools
 
     - name: Build WireGuard tools
       community.general.make:
-        chdir: /tmp/wireguard-tools/src
+        chdir: {{ wireguard_sources_path }}/wireguard-tools/src
 
     - name: Install WireGuard tools
       shell:
-        chdir: /tmp/wireguard-tools/src
+        chdir: {{ wireguard_sources_path }}/wireguard-tools/src
         cmd: checkinstall -y --pkgname wireguard-tools
 
   when: ansible_distribution == "Debian" and ansible_lsb.id == "Raspbian" and ansible_architecture == "armv6l"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,12 @@
 
 - name: Install WireGuard (Raspberry Pi 2, Raspberry Pi Zero W)
   block:
+    - name: Check if manual builds and reboots are required
+      assert:
+        that:
+          - allow_build_from_source is true
+        fail_msg: "The installation on this platform requires a manual build and possibly a reboot. Please allow these actions by setting the flag 'allow_build_from_source'"
+
     - name: Install compile dependencies
       apt:
         update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     update_cache: yes
     state: present
     name: raspberrypi-kernel-headers
+  register: raspberrypi_kernel_headers_result
   when: ansible_distribution == "Debian" and ansible_lsb.id == "Raspbian"
 
 - name: Install WireGuard (Raspberry Pi 2, Raspberry Pi Zero W)
@@ -71,6 +72,10 @@
         url: 'https://raw.githubusercontent.com/RPi-Distro/rpi-source/master/rpi-source'
         dest: '/usr/local/bin/rpi-source'
         mode: u=rwx,g=rx,o=rx
+
+    - name: Reboot Raspberry Pi and wait for it to come back up
+      reboot:
+      when: raspberrypi_kernel_headers_result.changed
 
     - name: Run rpi-source
       command: /usr/local/bin/rpi-source

--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -17,7 +17,7 @@ MTU = {{ wireguard_mtu }}
 [Peer]
 PublicKey = {{ hostvars[node].public.content | b64decode | trim }}
 AllowedIPs = {{ hostvars[node].vpn_ip }}
-Endpoint = {{ hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
+Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host'] | default(hostvars[node]['inventory_hostname'])) }}:{{ wireguard_port }}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
On the Raspberry Pi Zero W and possibly other devices with an armv61 architecture the installation from the Debian repo won't work because the version is not compiled for this architecture.
It is required to manually compile WireGuard from its source to install it. 