### PR TITLE
Added basic validation for interface config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -262,6 +262,20 @@
   run_once: true
   when: client_vpn_ip | length > 0
 
+- name: Provide config validation script
+  copy:
+    content: |
+      #!/bin/bash
+      if [ ! -f /sys/class/net/$1/operstate ]; then
+        exit 0
+      fi
+      symbolic_filename="${2%/*}/$1.conf"
+      unlink ${symbolic_filename}
+      ln -s $2 ${symbolic_filename}
+      wg syncconf $1 <(wg-quick strip ${symbolic_filename})
+    dest: "/tmp/validate_wireguard_config"
+    mode: 0755
+
 - name: Generate configs
   template:
     src: interface.conf.j2
@@ -269,6 +283,7 @@
     owner: root
     group: root
     mode: "u=rw,g=r,o="
+    validate: "/tmp/validate_wireguard_config {{ wireguard_network_name }} %s "
   register: config
   notify:
     - Enable wg-quick service


### PR DESCRIPTION
I have added a basic script that tries to validate the generated config.
I you have a working wireguard mesh, a single misconfigured host can corrupt every config on every peer. On restart of the service it won't come back up and therefore break the entire mesh. If you use SSH over the wireguard connection, this will lock you out.
This happened to me multiple times because the generation of my public key failed on one of my peers.

The script attempts to interactively apply the configuration to the interface. If that fails, the interface is at least not broken and the task fails. If the interactive configuration is successful the template module will copy it to its destination as usual and the service will be restarted.

I do not have terribly many constellations to check this works as intended without any unforeseen consequences. Do you think adding s.th. like this is a good idea or do you suspect it makes it more prone to unintended fails?
