### PR TITLE
fwmark option has been added

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,5 @@
 warn_list:
   - git-latest
+
+skip_list:
+  - fqcn-builtins

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,7 +13,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: pip3 install ansible ansible-lint molecule[docker] docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.yamllint
+++ b/.yamllint
@@ -34,3 +34,4 @@ rules:
 
 ignore: |
   .env
+  .venv

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ wireguard_path: "/etc/wireguard"
 
 wireguard_sources_path: "/var/cache"
 
+wireguard_network: {}
 wireguard_network_name: "private"
 
 debian_enable_backports: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ client_wireguard_dns: false
 wireguard_additional_peers: false
 wireguard_post_up: false
 wireguard_post_down: false
+
+wireguard_fwmark_enabled: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Build your own multi server private network using wireguard and ansible
   issue_tracker_url: https://github.com/mawalu/wireguard-private-networking/issues
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: "2.7"
   platforms:
   - name: Ubuntu
     versions:
@@ -13,17 +13,17 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: Archlinux
+  - name: ArchLinux
     versions:
     - all
   - name: EL
     versions:
-    - 7
-    - 8
-  - name: OpenSuse
+    - "7"
+    - "8"
+  - name: opensuse
     versions:
-    - 15.1
-    - 15.2
+    - "15.1"
+    - "15.2"
   galaxy_tags:
   - wireguard
   - vpn

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -293,7 +293,7 @@
     mode: "u=rw,g=,o="
   vars:
     ansible_connection: local
-  become: no
+  become: false
   run_once: true
   when:
     - not ansible_check_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,13 @@
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_major_version|int < 20
 
+- name: Install linux headers (Debian)
+  apt:
+    update_cache: yes
+    state: present
+    name: "linux-headers-{{ ansible_facts.kernel }}"
+  when: ansible_distribution == "Debian"
+
 - name: Add backports repository (Debian)
   block:
     - name: Add backports repository list (Debian)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -273,6 +273,16 @@
     - not ansible_check_mode
     - client_vpn_ip | length > 0
 
+- name: full mesh network
+  set_fact:
+    wireguard_hosts: "{{ play_hosts }}"
+  when: wireguard_network|length == 0
+
+- name: user controlled wireguard hosts
+  set_fact:
+    wireguard_hosts: "{{ wireguard_network.get(inventory_hostname,[]) }}"
+  when: wireguard_network|length > 0
+
 - name: Generate configs
   template:
     src: interface.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,13 +8,6 @@
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_major_version|int < 20
 
-- name: Install linux headers (Debian)
-  apt:
-    update_cache: yes
-    state: present
-    name: "linux-headers-{{ ansible_facts.kernel }}"
-  when: ansible_distribution == "Debian"
-
 - name: Add backports repository (Debian)
   block:
     - name: Add backports repository list (Debian)
@@ -131,13 +124,34 @@
 
   when: ansible_distribution == "Debian" and ansible_lsb.id == "Raspbian" and ansible_architecture == "armv6l"
 
-- name: Install wireguard (apt)
+- name: Install wireguard (ubuntu)
   apt:
     update_cache: yes
     state: present
     name: wireguard
   when:
-    - ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" and ansible_architecture != "armv6l"
+    - ansible_distribution == "Ubuntu"
+    - ansible_architecture != "armv6l"
+
+- name: Install wireguard (debian dkms)
+  apt:
+    update_cache: yes
+    state: present
+    name: wireguard-dkms
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_architecture != "armv6l"
+    - ansible_distribution_major_version|int <= 10
+
+- name: Install wireguard (debian)
+  apt:
+    update_cache: yes
+    state: present
+    name: wireguard
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_architecture != "armv6l"
+    - ansible_distribution_major_version|int > 10
 
 - name: Install wireguard (pacman)
   pacman:

--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -18,14 +18,14 @@ FwMark = {{ wireguard_fwmark | default(wireguard_port) }}
 {% endif %}
 {% endif %}
 
-{% for node in play_hosts %}
-{% if inventory_hostname != hostvars[node]['inventory_hostname'] %}
+{% for node in wireguard_hosts %}
+{%   if inventory_hostname != hostvars[node]['inventory_hostname'] %}
 [Peer]
 PublicKey = {{ hostvars[node].public.content | b64decode | trim }}
 AllowedIPs = {{ hostvars[node].vpn_ip }}
 Endpoint = {{ hostvars[node]['public_addr'] | default(hostvars[node]['ansible_host']) | default(hostvars[node]['inventory_hostname']) }}:{{ wireguard_port }}
 
-{% endif %}
+{%   endif %}
 {% endfor %}
 
 {% if client_vpn_ip | length > 0 %}

--- a/templates/interface.conf.j2
+++ b/templates/interface.conf.j2
@@ -13,6 +13,9 @@ MTU = {{ wireguard_mtu }}
 {% endif %}
 {% if client_wireguard_dns %}
 DNS = {{ client_wireguard_dns }}
+{% if wireguard_fwmark_enabled|bool %}
+FwMark = {{ wireguard_fwmark | default(wireguard_port) }}
+{% endif %}
 {% endif %}
 
 {% for node in play_hosts %}


### PR DESCRIPTION
FwMark wireguard option can be useful for example when you need to filter out all unencrypted traffic:
```
PostUp = iptables -I OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
PreDown = iptables -D OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
```

Additionally galaxy schema and linting were fixed. 